### PR TITLE
Allow spaces in mkfile file input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,10 @@
 
 # Debugger
 .gdb_history
+peda-session*
 
 
 # Application specific
 *.pem
 *.json
-
 userabc/

--- a/include/efs/utils.h
+++ b/include/efs/utils.h
@@ -1,8 +1,23 @@
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
 namespace Efs {
   class Utils {
-    std::string getFilenameFromFilepath(std::string filepath) {
-      std::string base_filename = path.substr(path.find_last_of("/\\") + 1)
-      return base_filename;
-    }
-  }
+    public:
+      // Gets filename from filepath
+      static std::string getFilenameFromFilepath(std::string filepath) {
+        std::string base_filename = filepath.substr(filepath.find_last_of("/\\") + 1);
+        return base_filename;
+      }
+
+      // joins a vector of string by the delimiter given
+      static std::string join(std::vector<std::string> const &strings, std::string delim) {
+        std::stringstream ss;
+        std::copy(strings.begin(), strings.end(), std::ostream_iterator<std::string>(ss, delim.c_str()));
+        return ss.str();
+      }
+  };
 }

--- a/src/efs.cpp
+++ b/src/efs.cpp
@@ -9,6 +9,7 @@
 #include <efs/cli.h>
 #include <efs/database.h>
 #include <efs/login.h>
+#include <efs/utils.h>
 
 Efs::Efs::Efs(int argc, char** argv) {
   Database database;
@@ -110,11 +111,18 @@ Efs::Efs::Efs(int argc, char** argv) {
       }
       cli.mkdir(currentUser, r_currentDir, v_currentDir, v_cmd[1], &database);
     } else if (v_cmd[0] == "mkfile") {
-      if (v_cmd.size() != 3) {
+      if (v_cmd.size() < 3) {
         std::cout << "Incorrect number of arguments!\n";
         std::cout << "Usage: mkfile <filename> <contents>\n";
         continue;
       }
+      // get the last argument as a vector slice so that we can have spaces in the file contents
+      std::vector v_file_contents = std::vector<std::string>(v_cmd.begin()+2, v_cmd.end());
+
+      // combine the last file_contents ivector nto a string delimited with space
+      std::string file_contents = Utils::join(v_file_contents, " ");
+
+      // call makefile on the combined file-contents
       cli.mkfile(currentUser, r_currentDir, v_currentDir, v_cmd[1], v_cmd[2], &database);
     } else if (v_cmd[0] == "exit") {
       std::cout << "Exiting" << std::endl;


### PR DESCRIPTION
Allow spaces for file creation. IE:

```sh
(EFS)$ mkfile random.txt "This is a cool PR"
```