### PR TITLE
Fix bug for multi-line mkfile

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -109,7 +109,7 @@ void Efs::CLI::cat(std::string filename) {
 
   // actual read
   try {
-    std::cout << this->filesystem_service.readFile(filepath, this->private_key) << std::endl;
+    std::cout << this->filesystem_service.readFile(filepath, this->private_key);
   } catch (FilesystemService::ReadFileException &ex) {
     std::cout << "Unable to read file" << std::endl;
     return;

--- a/src/efs.cpp
+++ b/src/efs.cpp
@@ -125,7 +125,7 @@ Efs::Efs::Efs(int argc, char** argv) {
       std::string file_contents = Utils::join(v_file_contents, " ");
 
       // call makefile on the combined file-contents
-      cli.mkfile(v_cmd[1], v_cmd[2]);
+      cli.mkfile(v_cmd[1], file_contents);
     } else if (v_cmd[0] == "exit") {
       std::cout << "Exiting" << std::endl;
       return;


### PR DESCRIPTION
- Use the joined arguments instead of the direct argument