### PR TITLE
Simplify some code && fix bug

### DIFF
--- a/include/efs/utils.h
+++ b/include/efs/utils.h
@@ -31,7 +31,7 @@ namespace Efs {
         std::string segment;
         std::vector<std::string> seglist;
         while(std::getline(ss_input, segment, delim)) {
-          seglist.push_back(segment);
+          if (!segment.empty()) seglist.push_back(segment);
         }
         return seglist;
       }
@@ -49,6 +49,18 @@ namespace Efs {
           if (name != "") return name;
         }
         return "";
+      }
+
+      /**
+       * @brief Determines if the v_path is in the personal folder
+       *
+       * @param v_path the virtual path
+       * @return true if they are in their personal directory </usera/personal/>
+       * @return false if they are not </usera/shared>
+       */
+      static bool isInPersonal(std::string v_path, std::string username) {
+        std::vector<std::string> split_path = Utils::splitString(v_path, '/');
+        return split_path.size() >= 2 && split_path[1] == "personal" && username == split_path[0];
       }
   };
 }

--- a/src/efs.cpp
+++ b/src/efs.cpp
@@ -37,8 +37,7 @@ Efs::Efs::Efs(int argc, char** argv) {
 
   std::cout << "Welcome back, " + username + "!" << std::endl;
 
-  // intialize dirs
-  std::string r_currentDir = (std::string) std::filesystem::current_path(); // TODO: Remove this
+  // intialize dir
   std::string v_currentDir = "/" + username + "/";
 
   // initialize the user's CLI


### PR DESCRIPTION
Fix a bug where user can cd into their shared directory in another user

```sh
[bob@EFS: /bob/personal/]$ mkfile bob.txt bob.txt
Created file!
[bob@EFS: /bob/personal/]$ share bob.txt alice
Shared file with alice at /alice/shared/bob/bob.txt
[bob@EFS: /bob/personal/]$ cd ../../../alice/shared/bob/
[bob@EFS: /alice/shared/bob/]$ ls
d -> .
d -> ..
f -> bob.txt
[bob@EFS: /alice/shared/bob/]$
[bob@EFS: /alice/shared/bob/]$
[bob@EFS: /alice/shared/bob/]$
[bob@EFS: /alice/shared/bob/]$
[bob@EFS: /alice/shared/bob/]$ cat bob.txt
Encountered error:Decryption failed
Unable to read file
[bob@EFS: /alice/shared/bob/]$ exit
```